### PR TITLE
Use the UserCountry plugin as base plugin

### DIFF
--- a/IntranetGeoIP.php
+++ b/IntranetGeoIP.php
@@ -11,23 +11,23 @@ use Piwik\Notification;
 // @see https://github.com/piwik/piwik/blob/b95837534c6fc4c9dd63eef2c2e9d8bb343ca23e/plugins/UserCountry/LocationProvider.php#L152
 require_once PIWIK_INCLUDE_PATH . '/plugins/IntranetGeoIP/Provider.php';
 
-class IntranetGeoIP extends Plugin
+final class IntranetGeoIP extends Plugin
 {
 
     /**
      *
      * @return string
      */
-    private function getDataExampleFilePath()
+    public static function getDataExampleFilePath()
     {
         return __DIR__ . '/data.example.php';
     }
-
+    
     /**
      *
      * @return string
      */
-    private function getDataFilePath()
+    public static function getDataFilePath()
     {
         return PIWIK_INCLUDE_PATH . '/config/IntranetGeoIP.data.php';
     }

--- a/IntranetGeoIP.php
+++ b/IntranetGeoIP.php
@@ -11,6 +11,10 @@ use Piwik\Notification;
 use Piwik\Plugins\PrivacyManager\Config as PrivacyManagerConfig;
 use Piwik\Tracker\Request as TrackerRequest;
 
+// This is need, that this provider is detected in this plugin 
+// @see https://github.com/piwik/piwik/blob/b95837534c6fc4c9dd63eef2c2e9d8bb343ca23e/plugins/UserCountry/LocationProvider.php#L152
+require_once PIWIK_INCLUDE_PATH . '/plugins/IntranetGeoIP/Provider.php';
+
 class IntranetGeoIP extends Plugin
 {
 

--- a/IntranetGeoIP.php
+++ b/IntranetGeoIP.php
@@ -5,11 +5,7 @@
 namespace Piwik\Plugins\IntranetGeoIP;
 
 use Piwik\Plugin;
-use Piwik\Network;
-use Piwik\Log;
 use Piwik\Notification;
-use Piwik\Plugins\PrivacyManager\Config as PrivacyManagerConfig;
-use Piwik\Tracker\Request as TrackerRequest;
 
 // This is need, that this provider is detected in this plugin 
 // @see https://github.com/piwik/piwik/blob/b95837534c6fc4c9dd63eef2c2e9d8bb343ca23e/plugins/UserCountry/LocationProvider.php#L152
@@ -34,17 +30,6 @@ class IntranetGeoIP extends Plugin
     private function getDataFilePath()
     {
         return PIWIK_INCLUDE_PATH . '/config/IntranetGeoIP.data.php';
-    }
-
-    /**
-     *
-     * @see Piwik\Plugin::getListHooksRegistered
-     */
-    public function getListHooksRegistered()
-    {
-        return array(
-            'Tracker.newVisitorInformation' => 'logIntranetSubNetworkInfo'
-        );
     }
 
     /**
@@ -87,53 +72,6 @@ class IntranetGeoIP extends Plugin
     {
         if (file_exists($this->getDataFilePath())) {
             unlink($this->getDataFilePath());
-        }
-    }
-
-    /**
-     * Called by event `Tracker.newVisitorInformation`
-     *
-     * @see getListHooksRegistered()
-     */
-    public function logIntranetSubNetworkInfo(&$visitorInfo, TrackerRequest $request)
-    {
-        if (! file_exists($this->getDataFilePath())) {
-            Log::error('Plugin IntranetGeoIP does not work. File is missing: ' . $this->getDataFilePath());
-            return;
-        }
-        
-        $data = include $this->getDataFilePath();
-        if ($data === false) {
-            // no data file found
-            // @todo ...inform the user/ log something
-            Log::error('Plugin IntranetGeoIP does not work. File is missing: ' . $this->getDataFilePath());
-            return;
-        }
-        
-        $privacyConfig = new PrivacyManagerConfig();
-        
-        $ipBinary = $request->getIp();
-        if ($privacyConfig->useAnonymizedIpForVisitEnrichment === true) {
-            $ipBinary = $visitorInfo['location_ip'];
-        }
-        
-        $ip = Network\IP::fromBinaryIP($ipBinary);
-        
-        foreach ($data as $value) {
-            if (isset($value['networks']) && $ip->isInRanges($value['networks']) === true) {
-                // values with the same key are not overwritten by right!
-                // http://www.php.net/manual/en/language.operators.array.php
-                if (isset($value['visitorInfo'])) {
-                    $visitorInfo = $value['visitorInfo'] + $visitorInfo;
-                }
-                return;
-            }
-        }
-        
-        // if nothing was matched, you can define default values if you want to
-        if (isset($data['noMatch']) && isset($data['noMatch']['visitorInfo'])) {
-            $visitorInfo = $data['noMatch']['visitorInfo'] + $visitorInfo;
-            return;
         }
     }
 }

--- a/Provider.php
+++ b/Provider.php
@@ -33,6 +33,7 @@ final class Provder extends LocationProvider
             '</em>',
             '</strong>'
         )) . '<p><em><a href="http://piwik.org/faq/how-to/#faq_163" rel="noreferrer"  target="_blank">' . Piwik::translate('UserCountry_HowToInstallGeoIPDatabases') . '</em></a></p>';
+        
         return array(
             'id' => self::ID,
             'title' => self::TITLE,
@@ -42,26 +43,32 @@ final class Provder extends LocationProvider
     }
 
     /**
-     * Returns whether this location provider is available.
+     * This implementation is available, as soon as the plugin is installed!
      *
-     * This implementation is always available.
-     *
-     * @return bool always true
+     * @return bool
      */
     public function isAvailable()
     {
-        return false;
+        return true;
     }
 
     /**
-     * Returns whether this location provider is working correctly.
+     * Test if the data file is around
      *
-     * This implementation is always working correctly.
-     *
-     * @return bool always true
+     * @return bool
      */
     public function isWorking()
     {
+        if(!file_exists(IntranetGeoIP::getDataFilePath())){
+            return 'Configuration file is missing: ' . IntranetGeoIP::getDataFilePath();
+        }
+        
+        $config = include IntranetGeoIP::getDataFilePath();
+        
+        if(count($config) === 1){
+            return 'Only default configuration given. Please edit the configuration file: ' . IntranetGeoIP::getDataFilePath();
+        }
+
         return true;
     }
 
@@ -96,15 +103,11 @@ final class Provder extends LocationProvider
      */
     public function getLocation($info)
     {
-        $enableLanguageToCountryGuess = Config::getInstance()->Tracker['enable_language_to_country_guess'];
-        
-        if (empty($info['lang'])) {
-            $info['lang'] = Common::getBrowserLanguage();
-        }
-        $country = Common::getCountry($info['lang'], $enableLanguageToCountryGuess, $info['ip']);
-        
+        // @todo this is only for testing!
         $location = array(
-            parent::COUNTRY_CODE_KEY => $country
+            parent::COUNTRY_CODE_KEY => 'at',
+            parent::ISP_KEY => 'github.com',
+            parent::ORG_KEY => 'OpenSource'
         );
         $this->completeLocationResult($location);
         

--- a/Provider.php
+++ b/Provider.php
@@ -1,0 +1,113 @@
+<?php
+namespace Piwik\Plugins\IntranetGeoIP;
+
+use Piwik\Common;
+use Piwik\Config;
+use Piwik\Piwik;
+use Piwik\Plugins\UserCountry\LocationProvider;
+
+final class Provder extends LocationProvider
+{
+
+    const ID = 'IntranetGeoIP';
+
+    const TITLE = 'IntranetGeoIP';
+
+    /**
+     * Returns information about this location provider.
+     * Contains an id, title & description:
+     *
+     * array(
+     * 'id' => 'default',
+     * 'title' => '...',
+     * 'description' => '...'
+     * );
+     *
+     * @return array
+     */
+    public function getInfo()
+    {
+        $desc = Piwik::translate('UserCountry_DefaultLocationProviderDesc1') . ' ' . Piwik::translate('UserCountry_DefaultLocationProviderDesc2', array(
+            '<strong>',
+            '<em>',
+            '</em>',
+            '</strong>'
+        )) . '<p><em><a href="http://piwik.org/faq/how-to/#faq_163" rel="noreferrer"  target="_blank">' . Piwik::translate('UserCountry_HowToInstallGeoIPDatabases') . '</em></a></p>';
+        return array(
+            'id' => self::ID,
+            'title' => self::TITLE,
+            'description' => $desc,
+            'order' => 20
+        );
+    }
+
+    /**
+     * Returns whether this location provider is available.
+     *
+     * This implementation is always available.
+     *
+     * @return bool always true
+     */
+    public function isAvailable()
+    {
+        return false;
+    }
+
+    /**
+     * Returns whether this location provider is working correctly.
+     *
+     * This implementation is always working correctly.
+     *
+     * @return bool always true
+     */
+    public function isWorking()
+    {
+        return true;
+    }
+
+    /**
+     * Returns an array describing the types of location information this provider will
+     * return.
+     *
+     * This provider supports the following types of location info:
+     * - continent code
+     * - continent name
+     * - country code
+     * - country name
+     *
+     * @return array
+     */
+    public function getSupportedLocationInfo()
+    {
+        return array(
+            self::CONTINENT_CODE_KEY => true,
+            self::CONTINENT_NAME_KEY => true,
+            self::COUNTRY_CODE_KEY => true,
+            self::COUNTRY_NAME_KEY => true
+        );
+    }
+
+    /**
+     * Guesses a visitor's location using a visitor's browser language.
+     *
+     * @param array $info
+     *            Contains 'ip' & 'lang' keys.
+     * @return array Contains the guessed country code mapped to LocationProvider::COUNTRY_CODE_KEY.
+     */
+    public function getLocation($info)
+    {
+        $enableLanguageToCountryGuess = Config::getInstance()->Tracker['enable_language_to_country_guess'];
+        
+        if (empty($info['lang'])) {
+            $info['lang'] = Common::getBrowserLanguage();
+        }
+        $country = Common::getCountry($info['lang'], $enableLanguageToCountryGuess, $info['ip']);
+        
+        $location = array(
+            parent::COUNTRY_CODE_KEY => $country
+        );
+        $this->completeLocationResult($location);
+        
+        return $location;
+    }
+}


### PR DESCRIPTION
Inspired by #9 i checked the default Piwik GeoIP providers and noticted, that i can easily integrate my plugin as a provider.

Following arguments are :+1:  for this change:
- the plugin is listed and checked in `Settings -> Geolocation`
- easiert to understand for users
- we can take advantage of CLI cmd(s) and maybe other things in the future http://piwik.org/faq/how-to/faq_167/

:-1:  for this change
- how we can handle mixed enviroments (internet and intranet)? Until yet you could activate a Provider from piwik and if this plugin matched the IP with a given intranet range it was just overwritten...
- there should be no other BC break or problem...

@mattab maybe you have an idea for the mixed enviroments?
